### PR TITLE
Feature: Login Screen v0

### DIFF
--- a/lib/login_screen.dart
+++ b/lib/login_screen.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+
+class LoginScreen extends StatefulWidget {
+  const LoginScreen({super.key});
+
+  @override
+  State<LoginScreen> createState() => _LoginScreenState();
+}
+
+class _LoginScreenState extends State<LoginScreen> {
+  
+  final TextEditingController _passwordController = TextEditingController();
+
+  String? _errorMessage;
+
+  void _attemptLogin(){
+    String pswd = _passwordController.text;
+    setState(() {
+      if(pswd.isEmpty){
+        _errorMessage = "Password cannot be empty.";
+      } else if (pswd == "1234") {
+        _errorMessage = null;
+        print("Login successful");
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Login Successful!'))
+        );
+      } else {
+        _errorMessage = "Incorrect password. Try again.";
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      // backgroundColor: Colors.black, // Ya viene del tema oscuro en main.dart
+      body: Center(
+        child: Padding(
+          padding: const EdgeInsets.all(30.0),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              const Icon(Icons.lock_person, size: 80, color: Colors.greenAccent),
+              const SizedBox(height: 20),
+              const Text(
+                "ACCESO AL BÚNKER",
+                style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+              ),
+              const SizedBox(height: 40),
+              
+              // CAMPO DE TEXTO
+              TextField(
+                controller: _passwordController,
+                obscureText: true, // Para que salgan puntitos ••••
+                decoration: InputDecoration(
+                  labelText: "Contraseña Maestra",
+                  errorText: _errorMessage, // Muestra el error si no es null
+                  border: const OutlineInputBorder(),
+                  prefixIcon: const Icon(Icons.key),
+                ),
+              ),
+              
+              const SizedBox(height: 20),
+              
+              // BOTÓN DE ACCESO
+              SizedBox(
+                width: double.infinity, // Ocupar todo el ancho posible
+                height: 50,
+                child: ElevatedButton(
+                  onPressed: _attemptLogin,
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: Colors.greenAccent,
+                    foregroundColor: Colors.black,
+                  ),
+                  child: const Text("DESBLOQUEAR"),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'login_screen.dart';
 
 void main() {
   runApp(const ElBunkerApp());
@@ -20,7 +21,7 @@ class ElBunkerApp extends StatelessWidget {
           primary: Colors.greenAccent, // Color de acento estilo terminal
         ),
       ),
-      home: const PantallaPrincipal(),
+      home: const LoginScreen(),
     );
   }
 }


### PR DESCRIPTION
This pull request introduces a new login flow to the app by adding a password-protected login screen and updating the app's entry point to use it. The main changes include creating a new `LoginScreen` widget with password validation and integrating it as the initial screen in the app.

**Authentication feature:**
* Added the new `LoginScreen` widget in `lib/login_screen.dart`, which includes a password field, error handling, and a login button. The screen validates the password and displays appropriate messages for success or failure.

**App initialization:**
* Imported the new `login_screen.dart` file in `lib/main.dart` to make the login screen available.
* Changed the app's home screen from `PantallaPrincipal` to `LoginScreen` in `lib/main.dart`, making the login screen the first thing users see when opening the app.