### PR TITLE
Refactor: Solved missmatch

### DIFF
--- a/lib/models/password_item.dart
+++ b/lib/models/password_item.dart
@@ -21,9 +21,9 @@ class PasswordItem {
       'id': id,
       'title': title,
       'user_name': username,
-      'encrypted_pswd': encryptedPswd,
+      'encrypted_password': encryptedPswd,
       'notes': notes,
-      'createdAt': createdAt.toIso8601String(), // DateTime saved as a String
+      'created_at': createdAt.toIso8601String(), // DateTime saved as a String
     };
   }
 
@@ -33,9 +33,9 @@ class PasswordItem {
       id: map['id'] as int?,
       title: map['title'] as String,
       username: map['user_name'] as String,
-      encryptedPswd: map['encrypted_pswd'] as String,
+      encryptedPswd: map['encrypted_password'] as String,
       notes: map['notes'] as String? ?? '', // Default to empty string if null
-      createdAt: DateTime.parse(map['createdAt'] as String),
+      createdAt: DateTime.parse(map['created_at'] as String),
     );
   }
 


### PR DESCRIPTION
This pull request updates the `PasswordItem` model to standardize field naming conventions for serialization and deserialization. The changes ensure consistency between the field names used in the Dart model and those stored in the database or transmitted over the network.

Field name standardization:

* Renamed the key `'encrypted_pswd'` to `'encrypted_password'` in both the `toMap` and `fromMap` methods of `PasswordItem` to use a more descriptive and consistent field name. [[1]](diffhunk://#diff-74a3bb4b15fac9de60805bcd7fbe8f5794866069e608d47e4a088d092fa1d0dbL24-R26) [[2]](diffhunk://#diff-74a3bb4b15fac9de60805bcd7fbe8f5794866069e608d47e4a088d092fa1d0dbL36-R38)
* Renamed the key `'createdAt'` to `'created_at'` in both the `toMap` and `fromMap` methods to follow snake_case naming conventions. [[1]](diffhunk://#diff-74a3bb4b15fac9de60805bcd7fbe8f5794866069e608d47e4a088d092fa1d0dbL24-R26) [[2]](diffhunk://#diff-74a3bb4b15fac9de60805bcd7fbe8f5794866069e608d47e4a088d092fa1d0dbL36-R38)