### PR TITLE
Feature: Update

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -102,6 +102,18 @@ class _HomeScreenState extends State<HomeScreen> {
               style: const TextStyle(fontWeight: FontWeight.bold),
             ),
             subtitle: Text(item.username),
+            onTap: () async {
+              final result = await Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (context) => AddPasswordScreen(itemToEdit: item),
+                ),
+              );
+              if (result == true) {
+                // Refresh the list if a password was edited
+                refreshPasswords();
+              }
+            },
             trailing: IconButton(
               icon: const Icon(Icons.delete_outline, color: Colors.redAccent),
               onPressed: () async {

--- a/lib/services/database_helper.dart
+++ b/lib/services/database_helper.dart
@@ -62,6 +62,18 @@ class DatabaseHelper {
     return await db.query('passwords', orderBy: 'created_at DESC');
   }
 
+  /// Updates an existing secret in the database
+  Future<int> update(Map<String, dynamic> row) async {
+    final db = await instance.database;
+    int id = row['id'];
+    return await db.update(
+      'passwords',
+      row,
+      where: 'id = ?',
+      whereArgs: [id],
+    );
+  }
+
   /// Deletes a secret by ID
   Future<int> delete(int id) async {
     final db = await instance.database;


### PR DESCRIPTION
This pull request adds password editing functionality to the app, allowing users to update existing secrets. The main changes include updating the UI and logic in `AddPasswordScreen` to support both creating and editing passwords, adding an update method to the database helper, and enabling navigation from the home screen to edit a selected password.

**Password editing feature:**

* [`lib/screens/add_password_screen.dart`](diffhunk://#diff-be79e99e47e079ebccbaa459e6eefe154bba07d8ffff9d2b6c88049d9c7e270aL6-R9): The `AddPasswordScreen` now accepts an optional `PasswordItem` parameter (`itemToEdit`). The screen initializes form fields with existing values if editing, updates the app bar title and button label based on mode, and decides whether to create or update a password entry when saving. [[1]](diffhunk://#diff-be79e99e47e079ebccbaa459e6eefe154bba07d8ffff9d2b6c88049d9c7e270aL6-R9) [[2]](diffhunk://#diff-be79e99e47e079ebccbaa459e6eefe154bba07d8ffff9d2b6c88049d9c7e270aL15-R31) [[3]](diffhunk://#diff-be79e99e47e079ebccbaa459e6eefe154bba07d8ffff9d2b6c88049d9c7e270aR46-L90) [[4]](diffhunk://#diff-be79e99e47e079ebccbaa459e6eefe154bba07d8ffff9d2b6c88049d9c7e270aL99-L100) [[5]](diffhunk://#diff-be79e99e47e079ebccbaa459e6eefe154bba07d8ffff9d2b6c88049d9c7e270aL111-R134)

**Database updates:**

* [`lib/services/database_helper.dart`](diffhunk://#diff-eae4de6744c79b77cdea27868a2f44d3c81d242e8722ad47c3cda56cce81ccefR65-R76): Added an `update` method to handle updating existing password entries in the database.

**Navigation and UI enhancements:**

* [`lib/screens/home_screen.dart`](diffhunk://#diff-935e56a557f0ab902a679f47de66345d9f47058bccb96f870e6383d19e2c86ddR105-R116): Tapping a password item now opens the `AddPasswordScreen` in edit mode, and the password list is refreshed upon successful update.