### PR TITLE
Refactor: Delete action has 2 steps confirmation

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -117,10 +117,39 @@ class _HomeScreenState extends State<HomeScreen> {
             trailing: IconButton(
               icon: const Icon(Icons.delete_outline, color: Colors.redAccent),
               onPressed: () async {
-                if (item.id != null) {
-                  await DatabaseHelper.instance.delete(item.id!);
-                  await refreshPasswords(); // Refresh the list after deletion
-                }
+                showDialog(
+                  context: context, 
+                  builder: (BuildContext ctx) {
+                    return AlertDialog(
+                      title: const Text('Are you sure?'),
+                      content: const Text('Do you want to delete this secret? This action cannot be undone.'),
+                      actions: [
+                        TextButton(
+                          onPressed: (){
+                            Navigator.of(ctx).pop();
+                          },
+                          child: const Text('Cancel', style: TextStyle(color: Colors.white)),
+                        ),
+                        TextButton(
+                          onPressed: () async {
+                            Navigator.of(ctx).pop();
+
+                            if (item.id != null) {
+                              await DatabaseHelper.instance.delete(item.id!);
+                              refreshPasswords();
+                              if (context.mounted) {
+                                ScaffoldMessenger.of(context).showSnackBar(
+                                  const SnackBar(content: Text('Secret deleted!')),
+                                );
+                              }
+                            }
+                          }, 
+                          child: const Text('Delete', style: TextStyle(color: Colors.redAccent))
+                        )
+                      ],
+                    );
+                  }
+                );
               },
             ),
           ),


### PR DESCRIPTION
This pull request enhances the user experience when deleting a secret from the `HomeScreen` by introducing a confirmation dialog and providing user feedback after deletion.

**User experience improvements:**

* Added a confirmation `AlertDialog` before deleting a secret to prevent accidental deletions. The dialog includes 'Cancel' and 'Delete' options, with appropriate styling and messaging.
* After deletion, displays a `SnackBar` notification to inform the user that the secret has been deleted.