### PR TITLE
Feature: Hide Show Password

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:bunker/services/database_helper.dart';
 import 'package:bunker/models/password_item.dart';
+import '../widgets/password_card.dart';
 import 'add_password_screen.dart';
 
 class HomeScreen extends StatefulWidget {
@@ -88,71 +89,55 @@ class _HomeScreenState extends State<HomeScreen> {
       itemCount: passwords.length,
       itemBuilder: (context, index) {
         final item = passwords[index];
-        return Card(
-          elevation: 3,
-          shape: RoundedRectangleBorder(borderRadius: BorderRadiusGeometry.circular(12)),  
-          margin: const EdgeInsets.only(bottom: 12),
-          child: ListTile(
-            leading: CircleAvatar(
-              backgroundColor: Colors.blueGrey[100],
-              child: const Icon(Icons.vpn_key, color: Colors.blueGrey),
-            ),
-            title: Text(
-              item.title,
-              style: const TextStyle(fontWeight: FontWeight.bold),
-            ),
-            subtitle: Text(item.username),
-            onTap: () async {
-              final result = await Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (context) => AddPasswordScreen(itemToEdit: item),
-                ),
-              );
-              if (result == true) {
-                // Refresh the list if a password was edited
-                refreshPasswords();
-              }
-            },
-            trailing: IconButton(
-              icon: const Icon(Icons.delete_outline, color: Colors.redAccent),
-              onPressed: () async {
-                showDialog(
-                  context: context, 
-                  builder: (BuildContext ctx) {
-                    return AlertDialog(
-                      title: const Text('Are you sure?'),
-                      content: const Text('Do you want to delete this secret? This action cannot be undone.'),
-                      actions: [
-                        TextButton(
-                          onPressed: (){
-                            Navigator.of(ctx).pop();
-                          },
-                          child: const Text('Cancel', style: TextStyle(color: Colors.white)),
-                        ),
-                        TextButton(
-                          onPressed: () async {
-                            Navigator.of(ctx).pop();
-
-                            if (item.id != null) {
-                              await DatabaseHelper.instance.delete(item.id!);
-                              refreshPasswords();
-                              if (context.mounted) {
-                                ScaffoldMessenger.of(context).showSnackBar(
-                                  const SnackBar(content: Text('Secret deleted!')),
-                                );
-                              }
-                            }
-                          }, 
-                          child: const Text('Delete', style: TextStyle(color: Colors.redAccent))
-                        )
-                      ],
-                    );
-                  }
+        
+        // Use the PasswordCard widget
+        return PasswordCard(
+          item: item,
+          
+          // What to do on tap (EDIT)
+          onTap: () async {
+            final result = await Navigator.push(
+              context,
+              MaterialPageRoute(
+                builder: (context) => AddPasswordScreen(itemToEdit: item),
+              ),
+            );
+            if (result == true) refreshPasswords();
+          },
+          
+          // What to do on delete (SHOW DIALOG)
+          onDelete: () {
+            showDialog(
+              context: context,
+              builder: (BuildContext ctx) {
+                return AlertDialog(
+                  title: const Text('Delete secret?'),
+                  content: Text('You are about to delete the password for "${item.title}". This action cannot be undone.'),
+                  actions: [
+                    TextButton(
+                      onPressed: () => Navigator.of(ctx).pop(),
+                      child: const Text('CANCEL', style: TextStyle(color: Colors.white)),
+                    ),
+                    TextButton(
+                      onPressed: () async {
+                        Navigator.of(ctx).pop(); // Close alert
+                        if (item.id != null) {
+                          await DatabaseHelper.instance.delete(item.id!);
+                          refreshPasswords(); // Refresh list
+                          if (mounted) {
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              const SnackBar(content: Text('Deleted successfully')),
+                            );
+                          }
+                        }
+                      },
+                      child: const Text('DELETE', style: TextStyle(color: Colors.redAccent)),
+                    ),
+                  ],
                 );
               },
-            ),
-          ),
+            );
+          },
         );
       },
     );

--- a/lib/widgets/password_card.dart
+++ b/lib/widgets/password_card.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import '../models/password_item.dart';
+
+class PasswordCard extends StatefulWidget {
+  final PasswordItem item;
+  final VoidCallback onTap;
+  final VoidCallback onDelete;
+
+  const PasswordCard({
+    super.key,
+    required this.item,
+    required this.onTap,
+    required this.onDelete,
+  });
+
+  @override
+  State<PasswordCard> createState() => _PasswordCardState();
+}
+
+class _PasswordCardState extends State<PasswordCard> {
+  bool _isObscured = true; // By default, password is obscured
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      elevation: 3,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12),
+      ),
+      margin: const EdgeInsets.only(bottom: 12),
+      child: ListTile(
+        contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+        // Left side icon: A key icon inside a circle avatar
+        leading: CircleAvatar(
+          backgroundColor: Colors.blueGrey[800],
+          child: const Icon(Icons.vpn_key, color: Colors.greenAccent),
+        ),
+
+        // Title and User
+        title: Text (
+          widget.item.title,
+          style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
+        ),
+        subtitle: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(widget.item.username, style: TextStyle(color: Colors.grey[400])),
+            const SizedBox(height: 4),
+            Row(
+              children: [
+                Icon(
+                  _isObscured ? Icons.lock_outline : Icons.lock_open,
+                  size: 14,
+                  color: _isObscured ? Colors.grey : Colors.greenAccent,
+                ),
+                const SizedBox(width: 6),
+
+                Expanded(
+                  child: Text(
+                    _isObscured ? '••••••••••••' : widget.item.encryptedPswd,
+                    style: TextStyle(
+                      fontFamily: 'Courier',
+                      color: _isObscured ? Colors.grey : Colors.white,
+                      fontWeight: _isObscured ? FontWeight.normal : FontWeight.bold,
+                    ),
+                    overflow: TextOverflow.ellipsis,
+                  )
+                )
+              ],
+            )
+          ],
+        ),
+        trailing: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            IconButton(
+              icon: Icon(
+                _isObscured ? Icons.visibility : Icons.visibility_off,
+                color: Colors.blueGrey,
+              ),
+              onPressed: () {
+                setState(() {
+                  _isObscured = !_isObscured;
+                });
+              },
+            ),
+            IconButton(
+              icon: const Icon(Icons.delete, color: Colors.redAccent),
+              onPressed: widget.onDelete,
+            ),
+          ],
+        ),
+        onTap: widget.onTap,
+      ),
+    );
+  }
+}


### PR DESCRIPTION
This pull request introduces a new reusable `PasswordCard` widget to encapsulate the display and interaction logic for password items on the home screen. The change improves code organization, UI consistency, and maintainability by separating concerns and making the UI more modular.

**UI Refactoring and Componentization:**

* Replaces the inline password display in `HomeScreen` with the new `PasswordCard` widget, passing handlers for edit and delete actions to keep UI logic modular and reusable.
* Adds the `PasswordCard` widget in `lib/widgets/password_card.dart`, which displays password details, supports toggling password visibility, and provides edit and delete actions with improved UI styling and user feedback.
* Updates the import statements in `home_screen.dart` to include the new `PasswordCard` widget.