### PR TITLE
Feature: Copy Password Button

### DIFF
--- a/lib/widgets/password_card.dart
+++ b/lib/widgets/password_card.dart
@@ -21,6 +21,20 @@ class PasswordCard extends StatefulWidget {
 class _PasswordCardState extends State<PasswordCard> {
   bool _isObscured = true; // By default, password is obscured
 
+  /// Auxiliary method to copy password to clipboard
+  void _copyToClipboard(BuildContext context, String text, String type) {
+    Clipboard.setData(ClipboardData(text: text));
+    ScaffoldMessenger.of(context).hideCurrentSnackBar();
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text('$type copied to clipboard'),
+        backgroundColor: Colors.greenAccent,
+        behavior: SnackBarBehavior.floating,
+        duration: const Duration(seconds: 2),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Card(

--- a/lib/widgets/password_card.dart
+++ b/lib/widgets/password_card.dart
@@ -61,6 +61,7 @@ class _PasswordCardState extends State<PasswordCard> {
           children: [
             Text(widget.item.username, style: TextStyle(color: Colors.grey[400])),
             const SizedBox(height: 4),
+            // Password display with lock icon
             Row(
               children: [
                 Icon(
@@ -70,6 +71,7 @@ class _PasswordCardState extends State<PasswordCard> {
                 ),
                 const SizedBox(width: 6),
 
+                // Password text
                 Expanded(
                   child: Text(
                     _isObscured ? '••••••••••••' : widget.item.encryptedPswd,
@@ -80,11 +82,26 @@ class _PasswordCardState extends State<PasswordCard> {
                     ),
                     overflow: TextOverflow.ellipsis,
                   )
-                )
+                ),
+
+                // Copy password button
+                IconButton(
+                  icon: const Icon(
+                    Icons.copy_all, 
+                    size: 20, 
+                    color: Colors.greenAccent
+                  ),
+                  tooltip: "Copy Password",
+                  onPressed: () {
+                    _copyToClipboard(context, widget.item.encryptedPswd, "Password");
+                  },
+                ),
               ],
             )
           ],
         ),
+
+        // Trailing icons: Toggle visibility and delete
         trailing: Row(
           mainAxisSize: MainAxisSize.min,
           children: [


### PR DESCRIPTION
This pull request enhances the `PasswordCard` widget by adding a user-friendly feature to copy passwords directly to the clipboard, along with visual and usability improvements. The main focus is on improving the password management experience within the app.

**Password copy functionality and UI improvements:**

* Added a `_copyToClipboard` helper method to handle copying text (such as passwords) to the clipboard and displaying a confirmation `SnackBar` to the user.
* Introduced a dedicated copy password button (`IconButton` with a copy icon) next to the displayed password, allowing users to easily copy their password with one tap.
* Added comments and minor UI clarifications for password display and copy button placement, improving code readability and maintainability. [[1]](diffhunk://#diff-7301f29fbb332a7a07ab61174d835255c83cee10e03748eddc701e3d5288675eR64) [[2]](diffhunk://#diff-7301f29fbb332a7a07ab61174d835255c83cee10e03748eddc701e3d5288675eR74)