### PR TITLE
Feature: Password Generator

### DIFF
--- a/lib/screens/add_password_screen.dart
+++ b/lib/screens/add_password_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'dart:math';
 import '../services/database_helper.dart';
 import '../models/password_item.dart';
 
@@ -38,6 +39,45 @@ class _AddPasswordScreenState extends State<AddPasswordScreen> {
     _passController.dispose();
     _notesController.dispose();
     super.dispose();
+  }
+
+  void _generatePassword() {
+    const length = 16;
+    const letters = 'abcdefghijklmnopqrstuvwxyz';
+    const uppers = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+    const numbers = '0123456789';
+    const specials = '@#%^*&!_';
+
+    const allChars = letters + uppers + numbers + specials;
+    final random = Random();
+
+    // Ensure the password contains at least one character from each category
+    List<String> passwordChars =[
+      letters[random.nextInt(letters.length)],
+      uppers[random.nextInt(uppers.length)],
+      numbers[random.nextInt(numbers.length)],
+      specials[random.nextInt(specials.length)],
+    ];
+
+    // Fill the rest of the password length with random characters from all categories
+    for (int i = 4; i < length; i++) {
+      passwordChars.add(allChars[random.nextInt(allChars.length)]);
+    }
+
+    passwordChars.shuffle();
+
+    setState(() {
+      _passController.text = passwordChars.join();
+    });
+
+    ScaffoldMessenger.of(context).hideCurrentSnackBar();
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(
+        content: Text('Password generated!'),
+        backgroundColor: Colors.greenAccent,
+        duration: Duration(seconds: 1),
+      ),
+    );
   }
 
   Future<void> _savePassword() async {

--- a/lib/screens/add_password_screen.dart
+++ b/lib/screens/add_password_screen.dart
@@ -113,7 +113,6 @@ class _AddPasswordScreenState extends State<AddPasswordScreen> {
 
   @override
   Widget build(BuildContext context) {
-    // Cambiamos el título de la pantalla según el modo
     final isEditing = widget.itemToEdit != null;
 
     return Scaffold(
@@ -146,15 +145,32 @@ class _AddPasswordScreenState extends State<AddPasswordScreen> {
                 validator: (value) => value!.isEmpty ? 'User is required' : null,
               ),
               const SizedBox(height: 16),
+              
+              // Password field with generate button
               TextFormField(
                 controller: _passController,
-                decoration: const InputDecoration(
+                obscureText: false, 
+                decoration: InputDecoration(
                   labelText: 'Password',
-                  prefixIcon: Icon(Icons.vpn_key),
-                  border: OutlineInputBorder(),
+                  prefixIcon: const Icon(Icons.vpn_key),
+                  border: const OutlineInputBorder(),
+                  suffixIcon: IconButton(
+                    icon: const Icon(Icons.flash_on, color: Colors.greenAccent),
+                    tooltip: "Generate secure password",
+                    onPressed: _generatePassword,
+                  ),
                 ),
                 validator: (value) => value!.isEmpty ? 'Password is required' : null,
               ),
+              // Hint text for password generation
+              const Padding(
+                padding: EdgeInsets.only(top: 5, left: 10),
+                child: Text(
+                  "Press the lightning ⚡ to generate a secure password",
+                  style: TextStyle(fontSize: 12, color: Colors.grey),
+                ),
+              ),
+
               const SizedBox(height: 16),
               TextFormField(
                 controller: _notesController,


### PR DESCRIPTION
This pull request enhances the password creation experience in the `AddPasswordScreen` by adding a password generator feature. Users can now generate a secure password with a single tap, ensuring strong password composition and improving usability.

**Password Generation Feature:**

* Added a `_generatePassword` method that creates a 16-character password containing at least one lowercase letter, one uppercase letter, one number, and one special character, ensuring password strength. The generated password is automatically filled into the password field and a confirmation snackbar is shown.
* Updated the password input field to include a lightning bolt (`⚡`) icon button (`Icons.flash_on`) as a suffix. Tapping this button triggers the password generator.
* Added a hint text below the password field to inform users about the new password generation feature.

**Code Improvements:**

* Imported `dart:math` to support random password generation.
* Cleaned up comments and improved code clarity in the widget build method.